### PR TITLE
Adjusted code to compile in VS 2015

### DIFF
--- a/include/meta_random.hpp
+++ b/include/meta_random.hpp
@@ -4,23 +4,15 @@
 #include <limits>
 
 namespace snowapril {
-
-    constexpr int DigitToInt(char c) {
-		return c - '0';
-	};
-
-	constexpr int RandomSeed(void) {
-		constexpr char time[] = __TIME__;
-
-		constexpr int seed = DigitToInt(time[7]) 		+
- 				     DigitToInt(time[6]) * 10 		+
-				     DigitToInt(time[4]) * 60 		+
-				     DigitToInt(time[3]) * 600 		+
-				     DigitToInt(time[1]) * 3600 	+
-				     DigitToInt(time[0]) * 36000;
-
-		return seed;
-	};
+    constexpr int RandomSeed(void) {
+        return '0'      * -40271 + // offset accounting for digits' ANSI offsets
+            __TIME__[7] *      1 +
+            __TIME__[6] *     10 +
+            __TIME__[4] *     60 +
+            __TIME__[3] *    600 +
+            __TIME__[1] *   3600 +
+            __TIME__[0] *  36000;
+    };
 
     template <unsigned int a,
               unsigned int c,

--- a/include/obfuscator.hpp
+++ b/include/obfuscator.hpp
@@ -48,8 +48,8 @@ namespace snowapril {
 			return buffer;
 		}
 	private:
-		constexpr int  encrypt(char c) { return (A*(c)+B) % 127; } ;
-		constexpr char decrypt(int c) { return positive_modulo((ExtendedEuclidian<127, A>::y ) *(c-B), 127); } ;
+		constexpr int  encrypt(char c) const { return (A * c + B) % 127; } ;
+		constexpr char decrypt(int c) const { return positive_modulo(ExtendedEuclidian<127, A>::y * (c - B), 127); } ;
 	private:
 		char buffer[sizeof...(I) + 1] {};
 		int  encrypted_buffer[sizeof...(I)] {};


### PR DESCRIPTION
Wanted to do some experimentation for a work project still using MSVC 2015.

While doing so I've received a warning and an error, which are fixed by this PR:

* `MetaString::encrypt` and `MetaString::decrypt` are now both explicitly `const`. While this is implied in C++11, it was changed for C++14: Now you have to explicitly state `const`, too. Not doing so triggers warning C4814, which is no longer documented (for some odd reason).
* `RandomSeed` previously used two local variables, `time` and `seed`, but their declarations aren't allowed when using MSVC2015. Trying to do so triggers error C3250. As a fix, I've reworked the function to inline the use of `__TIME__`. The "magic number" of `-40271` is the negative sum of all multiplications used for the seed generation (to account for no longer subtracting `'0'` before multiplication).
* The code still requires C++14 (for `std::index_sequence`), which is partially implemented in MSVC 2015.

Tested building with MSVC 2015, MSVC 2019, LLVM/Clang 8.0.1, and GCC 8.1.0 (all on Windows x64).